### PR TITLE
Allow underscore characters in GitHub project names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var path;
 try {
   fs = require('fs');
   path = require('path');
-} catch (err) { }
+} catch (err) {}
 
 /* Username may only contain alphanumeric characters or
  * single hyphens, and cannot begin or end with a hyphen.

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ try {
  */
 var NAME = '(?:[a-z0-9]{1,2}|[a-z0-9][a-z0-9-]{1,37}[a-z0-9])';
 var USER = '(' + NAME + ')';
-var PROJECT = '((?:[a-z0-9-]|\\.git[a-z0-9-]|\\.(?!git))+)';
+var PROJECT = '((?:[a-z0-9-_]|\\.git[a-z0-9-]|\\.(?!git))+)';
 var REPO = USER + '\\/' + PROJECT;
 
 /* Match a repo from a git / github URL. */

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ function github(options) {
     throw new Error('Missing `repository` field in `options`');
   }
 
-  repository = { user: repository[1], project: repository[2] };
+  repository = {user: repository[1], project: repository[2]};
 
   /* Add helpers. */
   proto.githubRepo = repository;
@@ -120,13 +120,13 @@ function github(options) {
       children = [];
 
       if (base) {
-        children.push({ type: 'text', value: base + '@' });
+        children.push({type: 'text', value: base + '@'});
       }
 
-      children.push({ type: 'inlineCode', value: abbr(link.reference) });
+      children.push({type: 'inlineCode', value: abbr(link.reference)});
 
       if (link.comment) {
-        children.push({ type: 'text', value: comment });
+        children.push({type: 'text', value: comment});
       }
     } else {
       base += '#';

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var path;
 try {
   fs = require('fs');
   path = require('path');
-} catch (err) {}
+} catch (err) { }
 
 /* Username may only contain alphanumeric characters or
  * single hyphens, and cannot begin or end with a hyphen.
@@ -32,7 +32,7 @@ try {
  */
 var NAME = '(?:[a-z0-9]{1,2}|[a-z0-9][a-z0-9-]{1,37}[a-z0-9])';
 var USER = '(' + NAME + ')';
-var PROJECT = '((?:[a-z0-9-_]|\\.git[a-z0-9-]|\\.(?!git))+)';
+var PROJECT = '((?:[_.A-Za-z0-9-]|\\.git[_.A-Za-z0-9-]|\\.(?!git))+)';
 var REPO = USER + '\\/' + PROJECT;
 
 /* Match a repo from a git / github URL. */
@@ -70,7 +70,7 @@ function github(options) {
     throw new Error('Missing `repository` field in `options`');
   }
 
-  repository = {user: repository[1], project: repository[2]};
+  repository = { user: repository[1], project: repository[2] };
 
   /* Add helpers. */
   proto.githubRepo = repository;
@@ -120,13 +120,13 @@ function github(options) {
       children = [];
 
       if (base) {
-        children.push({type: 'text', value: base + '@'});
+        children.push({ type: 'text', value: base + '@' });
       }
 
-      children.push({type: 'inlineCode', value: abbr(link.reference)});
+      children.push({ type: 'inlineCode', value: abbr(link.reference) });
 
       if (link.comment) {
-        children.push({type: 'text', value: comment});
+        children.push({ type: 'text', value: comment });
       }
     } else {
       base += '#';


### PR DESCRIPTION
Although `package.json` does not allow for underscores in the `name` field, GitHub repository URLs allow underscores, and some languages, such as Dart, prefer them. I made a small addition to the regular expression for detecting and validating the project name to avoid the following confusing error message:
```shell
1:1  error  Error: Missing `repository` field in `options`
    at Function.github (/Users/4cm4k1/Code/normalize_css/node_modules/remark-github/lib/index.js:71:11)
```
Please let me know if this is acceptable. 😄