### PR TITLE
Fix links to longer projects, or projects with dots

### DIFF
--- a/lib/util/parse-link.js
+++ b/lib/util/parse-link.js
@@ -2,6 +2,7 @@
 
 var toString = require('mdast-util-to-string')
 var usernameEnd = require('./username-end')
+var projectEnd = require('./project-end')
 var issueEnd = require('./issue-end')
 var shaEnd = require('./sha-end')
 
@@ -44,7 +45,7 @@ function parse(node) {
   link.user = url.slice(start, end)
 
   start = end + 1
-  end = usernameEnd(url, start)
+  end = projectEnd(url, start)
 
   if (end === -1 || url.charCodeAt(end) !== CC_SLASH) {
     return

--- a/test/fixtures/links/input.md
+++ b/test/fixtures/links/input.md
@@ -54,6 +54,9 @@ Across repositories:
 Same user, different repository:
 <https://github.com/wooorm/bar/commit/1f2a>
 
+With dots (GH-14)
+<https://github.com/wooorm/wooorm.github.io/commit/e5bd>
+
 ## Commit comments
 
 A commit comment:

--- a/test/fixtures/links/output.md
+++ b/test/fixtures/links/output.md
@@ -54,6 +54,9 @@ Across repositories:
 Same user, different repository:
 [wooorm/bar@`1f2a`](https://github.com/wooorm/bar/commit/1f2a)
 
+With dots ([GH-14](https://github.com/wooorm/remark/issues/14))
+[wooorm/wooorm.github.io@`e5bd`](https://github.com/wooorm/wooorm.github.io/commit/e5bd)
+
 ## Commit comments
 
 A commit comment:

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,9 @@ test('remark-github()', function(t) {
   t.equal(typeof remarkGitHub, 'function', 'should be a function')
 
   t.doesNotThrow(function() {
-    remark().use(remarkGitHub).freeze()
+    remark()
+      .use(remarkGitHub)
+      .freeze()
   }, 'should not throw if not passed options')
 
   t.equal(
@@ -115,7 +117,8 @@ var repositories = [
   ['mame/_', 'mame', '_'],
   ['github/.gitignore', 'github', '.gitignore'],
   ['github/.gitc', 'github', '.gitc'],
-  ['Qix-/color-convert', 'Qix-', 'color-convert']
+  ['Qix-/color-convert', 'Qix-', 'color-convert'],
+  ['wooorm/wooorm.github.io', 'wooorm', 'wooorm.github.io']
 ]
 
 test('Repositories', function(t) {


### PR DESCRIPTION
Previously, a bug existed because the project part of a link (`bar` in
`https://github.com/foo/bar`) was checked against the algorithm for usernames
instead of the algorithm for projects.  Usernames are stricter (such as not
allowing dots and being max 39 characters), which caused some links to not be
matched (such as those with dots, or those longer than 39 characters).

Closes GH-14.