### PR TITLE
Remove handling of @mention linking to blog post

### DIFF
--- a/lib/tokenizer/mention.js
+++ b/lib/tokenizer/mention.js
@@ -9,21 +9,15 @@ module.exports = mention
 mention.locator = locator
 mention.notInLink = true
 
-var own = {}.hasOwnProperty
-
 var slash = 47 // '/'
 var atSign = 64 //  '@'
 
 var atSignCharacter = '@'
 
-// Map of overwrites for at-mentions.
-// GitHub does some fancy stuff with `@mention`, by linking it to their blog
-// post introducing the feature.
-// To my knowledge, there are no other magical usernames.
-var overwrites = {
-  mention: 'blog/821',
-  mentions: 'blog/821'
-}
+// Previously, GitHub linked `@mention` and `@mentions` to their blog post about
+// mentions (<https://github.com/blog/821>).
+// Since June 2019, and possibly earlier, they stopped linking those references.
+var denylist = ['mention', 'mentions']
 
 // Tokenise a mention.
 function mention(eat, value, silent) {
@@ -55,17 +49,21 @@ function mention(eat, value, silent) {
     }
   }
 
+  handle = value.slice(1, index)
+
+  if (denylist.indexOf(handle) !== -1) {
+    return
+  }
+
   /* istanbul ignore if - Maybe used by plugins? */
   if (silent) {
     return true
   }
 
   now = eat.now()
-  handle = value.slice(1, index)
   subvalue = atSignCharacter + handle
 
-  href = gh()
-  href += own.call(overwrites, handle) ? overwrites[handle] : handle
+  href = gh() + handle
 
   now.column++
 

--- a/readme.md
+++ b/readme.md
@@ -108,8 +108,7 @@ issues, PRs, and comments (see [Writing on GitHub][writing-on-github]).
 *   Issues across projects:
     `remarkjs/remark-github#1` → [remarkjs/remark-github#1][project-issue]
 *   At-mentions:
-    `@mention` and `@wooorm` →
-    [**@mention**][mentions] and [**@wooorm**][mention]
+    `@wooorm` → [**@wooorm**][mention]
 
 ###### Repository
 
@@ -198,7 +197,5 @@ abide by its terms.
 [user-issue]: https://github.com/remarkjs/remark-github/issues/1
 
 [project-issue]: https://github.com/remarkjs/remark-github/issues/1
-
-[mentions]: https://github.com/blog/821
 
 [mention]: https://github.com/wooorm

--- a/test/fixtures/mention/input.md
+++ b/test/fixtures/mention/input.md
@@ -4,7 +4,7 @@ A mention links to a user, organisation, or team.
 
 For example, @user, @organization, or @organization/team-name.
 
-Additionally, GitHub does something funny with @mention’s and @mentions.
+GitHub ignores @mention and @mentions.
 
 Some valid real world examples: @a, @github, @github/security.
 

--- a/test/fixtures/mention/output.md
+++ b/test/fixtures/mention/output.md
@@ -4,7 +4,7 @@ A mention links to a user, organisation, or team.
 
 For example, [**@user**](https://github.com/user), [**@organization**](https://github.com/organization), or [**@organization/team-name**](https://github.com/organization/team-name).
 
-Additionally, GitHub does something funny with [**@mention**](https://github.com/blog/821)’s and [**@mentions**](https://github.com/blog/821).
+GitHub ignores @mention and @mentions.
 
 Some valid real world examples: [**@a**](https://github.com/a), [**@github**](https://github.com/github), [**@github/security**](https://github.com/github/security).
 

--- a/test/index.js
+++ b/test/index.js
@@ -26,14 +26,14 @@ test('remark-github()', function(t) {
   }, 'should not throw if not passed options')
 
   t.equal(
-    github('@mention'),
-    '[**@mention**](https://github.com/blog/821)\n',
+    github('@wooorm'),
+    '[**@wooorm**](https://github.com/wooorm)\n',
     'should wrap mentions in `strong` by default'
   )
 
   t.equal(
-    github('@mention', {mentionStrong: false}),
-    '[@mention](https://github.com/blog/821)\n',
+    github('@wooorm', {mentionStrong: false}),
+    '[@wooorm](https://github.com/wooorm)\n',
     'should support `mentionStrong: false`'
   )
 


### PR DESCRIPTION
Previously, GitHub linked `@mention` and `@mentions` to their blog post
introducing the feature (<https://github.com/blog/821>, now at
<https://github.blog/2011-03-23-mention-somebody-they-re-notified/>).

GitHub removed this special handling, instead now no longer linking those
mentions.

Closes GH-16.
Closes GH-17.
