### PR TITLE
clarify repository option format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,8 @@ In Node this is detected automatically by loading `package.json` and looking for
 a `repository` field.
 In the browser, or when overwriting this, you can pass a `repository` in
 `options`.  
-Note: `repository` expects a `user/repo` pairing.
+The value of `repository` should be a URL to a GitHub repository, such as
+`'https://github.com/user/project.git'`, or only `'user/project'`.
 
 ###### Mentions
 

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,8 @@ These links are generated relative to a project.
 In Node this is detected automatically by loading `package.json` and looking for
 a `repository` field.
 In the browser, or when overwriting this, you can pass a `repository` in
-`options`.
+`options`.  
+Note: `repository` expects a `user/repo` pairing.
 
 ###### Mentions
 


### PR DESCRIPTION
Hey!
This tripped me up for a bit so I wanted to point out that `repository` doesn't expect a single repository name, but a `user/repo` combination ✌️ 