### PR TITLE
Add support for base URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var visit = require('unist-util-visit')
 var parse = require('./util/parse-link')
 var abbr = require('./util/abbreviate')
+var resolveBaseUrl = require('./util/resolve-base-url')
 var repo = require('./tokenizer/repo')
 var mention = require('./tokenizer/mention')
 var issue = require('./tokenizer/issue')
@@ -39,23 +40,30 @@ var repositoryExpression = new RegExp(
 function github(options) {
   var settings = options || {}
   var repository = settings.repository
+  var baseUrl = settings.baseUrl
   var proto = this.Parser.prototype
   var scope = proto.inlineTokenizers
   var methods = proto.inlineMethods
   var pack
 
   // Get the repository from `package.json`.
-  if (!repository) {
+  if (!repository || !baseUrl) {
     try {
       pack = JSON.parse(fs.readFileSync(path.join(proc.cwd(), 'package.json')))
     } catch (_) {
       pack = {}
     }
 
-    if (pack.repository) {
-      repository = pack.repository.url || pack.repository
-    } else {
-      repository = ''
+    if (!repository) {
+      if (pack.repository) {
+        repository = pack.repository.url || pack.repository
+      } else {
+        repository = ''
+      }
+    }
+
+    if (!baseUrl) {
+      baseUrl = resolveBaseUrl(repository)
     }
   }
 
@@ -71,6 +79,7 @@ function github(options) {
   repository = {user: repository[1], project: repository[2]}
 
   // Add helpers.
+  proto.githubBaseUrl = baseUrl
   proto.githubRepo = repository
   proto.githubOptions = settings
 

--- a/lib/tokenizer/hash.js
+++ b/lib/tokenizer/hash.js
@@ -66,7 +66,8 @@ function hash(eat, value, silent) {
   node = eat(subvalue)({
     type: 'link',
     title: null,
-    url: gh(self.githubRepo) + commitPage + slash + subvalue,
+    url:
+      gh(self.githubBaseUrl, self.githubRepo) + commitPage + slash + subvalue,
     children: self.tokenizeInline(subvalue, now)
   })
 

--- a/lib/tokenizer/issue.js
+++ b/lib/tokenizer/issue.js
@@ -56,7 +56,11 @@ function issue(eat, value, silent) {
   node = eat(subvalue)({
     type: 'link',
     title: null,
-    url: gh(self.githubRepo) + issuePage + slash + value.slice(start, index),
+    url:
+      gh(self.githubBaseUrl, self.githubRepo) +
+      issuePage +
+      slash +
+      value.slice(start, index),
     children: self.tokenizeInline(subvalue, now)
   })
 

--- a/lib/tokenizer/mention.js
+++ b/lib/tokenizer/mention.js
@@ -63,7 +63,7 @@ function mention(eat, value, silent) {
   now = eat.now()
   subvalue = atSignCharacter + handle
 
-  href = gh() + handle
+  href = gh(self.githubBaseUrl) + handle
 
   now.column++
 

--- a/lib/tokenizer/repo.js
+++ b/lib/tokenizer/repo.js
@@ -103,7 +103,7 @@ function repoReference(eat, value, silent) {
 
   handle = value.slice(0, handleEnd)
   project = projectEnd && value.slice(projectStart, projectEnd)
-  href = gh(handle, project || self.githubRepo.project)
+  href = gh(self.githubBaseUrl, handle, project || self.githubRepo.project)
   subvalue = value.slice(0, index)
   handle += (project ? slashCharacter + project : '') + delimiter
   add = eat(subvalue)

--- a/lib/util/gh.js
+++ b/lib/util/gh.js
@@ -2,6 +2,8 @@
 
 module.exports = gh
 
+const {URL} = require('url')
+
 // Return a URL to GitHub, relative to an optional `repo` object, or `user` and
 // `project`.
 function gh(base, repo, project) {
@@ -10,7 +12,7 @@ function gh(base, repo, project) {
   }
 
   if (repo) {
-    return base + '/' + repo.user + '/' + repo.project + '/'
+    return new URL('/' + repo.user + '/' + repo.project, base) + '/'
   }
 
   return base + '/'

--- a/lib/util/gh.js
+++ b/lib/util/gh.js
@@ -2,8 +2,6 @@
 
 module.exports = gh
 
-var url = require('url')
-
 // Return a URL to GitHub, relative to an optional `repo` object, or `user` and
 // `project`.
 function gh(base, repo, project) {
@@ -12,8 +10,8 @@ function gh(base, repo, project) {
   }
 
   if (repo) {
-    return url.resolve(base, '/' + repo.user + '/' + repo.project + '/')
+    return base + '/' + repo.user + '/' + repo.project + '/'
   }
 
-  return base
+  return base + '/'
 }

--- a/lib/util/gh.js
+++ b/lib/util/gh.js
@@ -2,17 +2,17 @@
 
 module.exports = gh
 
+var url = require('url')
+
 // Return a URL to GitHub, relative to an optional `repo` object, or `user` and
 // `project`.
-function gh(repo, project) {
-  var base = 'https://github.com/'
-
+function gh(base, repo, project) {
   if (project) {
     repo = {user: repo, project: project}
   }
 
   if (repo) {
-    base += repo.user + '/' + repo.project + '/'
+    return url.resolve(base, '/' + repo.user + '/' + repo.project + '/')
   }
 
   return base

--- a/lib/util/resolve-base-url.js
+++ b/lib/util/resolve-base-url.js
@@ -1,0 +1,15 @@
+'use strict'
+
+var url = require('url')
+
+module.exports = resolveBaseUrl
+
+function resolveBaseUrl(repository) {
+  var parsed = url.parse(repository)
+
+  if (parsed.host) {
+    return 'https://' + parsed.host + '/'
+  }
+
+  return 'https://github.com/'
+}

--- a/lib/util/resolve-base-url.js
+++ b/lib/util/resolve-base-url.js
@@ -1,15 +1,16 @@
 'use strict'
 
-var url = require('url')
+var {URL} = require('url')
 
 module.exports = resolveBaseUrl
 
 function resolveBaseUrl(repository) {
-  var parsed = url.parse(repository)
+  try {
+    var parsed = new URL(repository)
 
-  if (parsed.host) {
-    return 'https://' + parsed.host + '/'
+    return 'https://' + parsed.host
+  } catch (_) {
+    // If provided repository is simply "owner/repo" new URL() will throw TypeError[ERR_INVALID_URL]
+    return 'https://github.com'
   }
-
-  return 'https://github.com/'
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "esnext": false,
     "rules": {
       "unicorn/prefer-optional-catch-binding": "off",
-      "unicorn/prefer-includes": "off"
+      "unicorn/prefer-includes": "off",
+      "node/no-deprecated-api": "warn"
     },
     "ignores": [
       "remark-github.js"

--- a/package.json
+++ b/package.json
@@ -82,8 +82,7 @@
     "esnext": false,
     "rules": {
       "unicorn/prefer-optional-catch-binding": "off",
-      "unicorn/prefer-includes": "off",
-      "node/no-deprecated-api": "warn"
+      "unicorn/prefer-includes": "off"
     },
     "ignores": [
       "remark-github.js"

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,23 @@ Automatically link references to commits, issues, pull-requests, and users, like
 in GitHub issues, PRs, and comments (see
 [Writing on GitHub][writing-on-github]).
 
-###### Conversion
+##### Options
+
+###### `options.repository`
+
+These links are generated relative to a project.
+In Node this is detected automatically by loading `package.json` and looking for
+a `repository` field.
+In the browser, or when overwriting this, you can pass a `repository` in
+`options`.
+The value of `repository` should be a URL to a GitHub repository, such as
+`'https://github.com/user/project.git'`, or only `'user/project'`.
+
+###### `options.baseUrl`
+
+By default base URL is determined from the `repository` (with the fallback to `'https://github.com'`). You can override this (e.g. when using GitHub Enterprise) by providing custom `baseUrl`.
+
+##### Conversion
 
 *   Commits:
     `1f2a4fb` → [`1f2a4fb`][sha]
@@ -110,17 +126,7 @@ in GitHub issues, PRs, and comments (see
 *   At-mentions:
     `@wooorm` → [**@wooorm**][mention]
 
-###### Repository
-
-These links are generated relative to a project.
-In Node this is detected automatically by loading `package.json` and looking for
-a `repository` field.
-In the browser, or when overwriting this, you can pass a `repository` in
-`options`.
-The value of `repository` should be a URL to a GitHub repository, such as
-`'https://github.com/user/project.git'`, or only `'user/project'`.
-
-###### Mentions
+##### Mentions
 
 By default, mentions are wrapped in `strong` nodes (that render to `<strong>` in
 HTML), to simulate the look of mentions on GitHub.

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,9 @@ The value of `repository` should be a URL to a GitHub repository, such as
 
 ###### `options.baseUrl`
 
-By default base URL is determined from the `repository` (with the fallback to `'https://github.com'`). You can override this (e.g. when using GitHub Enterprise) by providing custom `baseUrl`.
+By default base URL is determined from the `repository` (with the fallback to  
+`'https://github.com'`).  You can override this (e.g. when using GitHub  
+Enterprise) by providing custom `baseUrl`.
 
 ##### Conversion
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,70 +56,100 @@ test('Fixtures', function (t) {
 // List of repo references possible in `package.json`s.
 // From repo-utils/parse-github-repo-url, with some tiny additions.
 var repositories = [
-  ['component/emitter', 'component', 'emitter'],
-  ['https://github.com/component/emitter', 'component', 'emitter'],
-  ['git://github.com/component/emitter.git', 'component', 'emitter'],
+  ['component/emitter', 'component', 'emitter', 'https://github.com/'],
+  [
+    'https://github.com/component/emitter',
+    'component',
+    'emitter',
+    'https://github.com/'
+  ],
+  [
+    'git://github.com/component/emitter.git',
+    'component',
+    'emitter',
+    'https://github.com/'
+  ],
   [
     'https://github.com/repos/component/emitter/tarball',
     'component',
-    'emitter'
+    'emitter',
+    'https://github.com/'
   ],
   [
     'https://github.com/repos/component/emitter/zipball',
     'component',
-    'emitter'
+    'emitter',
+    'https://github.com/'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.zip',
     'component',
-    'emitter'
+    'emitter',
+    'https://codeload.github.com/'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.tar.gz',
     'component',
-    'emitter'
+    'emitter',
+    'https://codeload.github.com/'
   ],
-  ['component/emitter#1', 'component', 'emitter'],
-  ['component/emitter@1', 'component', 'emitter'],
-  ['component/emitter#"1"', 'component', 'emitter'],
-  ['component/emitter@"1"', 'component', 'emitter'],
-  ['git://github.com/component/emitter.git#1', 'component', 'emitter'],
+  ['component/emitter#1', 'component', 'emitter', 'https://github.com/'],
+  ['component/emitter@1', 'component', 'emitter', 'https://github.com/'],
+  ['component/emitter#"1"', 'component', 'emitter', 'https://github.com/'],
+  ['component/emitter@"1"', 'component', 'emitter', 'https://github.com/'],
+  [
+    'git://github.com/component/emitter.git#1',
+    'component',
+    'emitter',
+    'https://github.com/'
+  ],
   [
     'https://github.com/repos/component/emitter/tarball/1',
     'component',
-    'emitter'
+    'emitter',
+    'https://github.com/'
   ],
   [
     'https://github.com/repos/component/emitter/zipball/1',
     'component',
-    'emitter'
+    'emitter',
+    'https://github.com/'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.zip/1',
     'component',
-    'emitter'
+    'emitter',
+    'https://codeload.github.com/'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.tar.gz/1',
     'component',
-    'emitter'
+    'emitter',
+    'https://codeload.github.com/'
   ],
   [
     'https://github.com/component/emitter/archive/1.tar.gz',
     'component',
-    'emitter'
+    'emitter',
+    'https://github.com/'
   ],
-  ['mame/_', 'mame', '_'],
-  ['github/.gitignore', 'github', '.gitignore'],
-  ['github/.gitc', 'github', '.gitc'],
-  ['Qix-/color-convert', 'Qix-', 'color-convert'],
-  ['wooorm/wooorm.github.io', 'wooorm', 'wooorm.github.io']
+  ['mame/_', 'mame', '_', 'https://github.com/'],
+  ['github/.gitignore', 'github', '.gitignore', 'https://github.com/'],
+  ['github/.gitc', 'github', '.gitc', 'https://github.com/'],
+  ['Qix-/color-convert', 'Qix-', 'color-convert', 'https://github.com/'],
+  [
+    'wooorm/wooorm.github.io',
+    'wooorm',
+    'wooorm.github.io',
+    'https://github.com/'
+  ]
 ]
 
 test('Repositories', function (t) {
   repositories.forEach(function (repo) {
     var user = repo[1]
     var project = repo[2]
+    var baseUrl = repo[3]
 
     repo = repo[0]
 
@@ -136,27 +166,24 @@ test('Repositories', function (t) {
         repo
       ),
       [
-        '-   SHA: [`a5c3785`](https://github.com/' +
+        '-   SHA: [`a5c3785`](' +
+          baseUrl +
           user +
           '/' +
           project +
           '/commit/a5c3785ed8d6a35868bc169f07e40e' +
           '889087fd2e)',
-        '-   User@SHA: [wooorm@`a5c3785`](https://github.com/wooorm/' +
+        '-   User@SHA: [wooorm@`a5c3785`](' +
+          baseUrl +
+          'wooorm/' +
           project +
           '/commit/a5c3785ed8d6a35868bc169f07e40e' +
           '889087fd2e)',
-        '-   # Num: [#26](https://github.com/' +
-          user +
-          '/' +
-          project +
-          '/issues/26)',
-        '-   GH-Num: [GH-26](https://github.com/' +
-          user +
-          '/' +
-          project +
-          '/issues/26)',
-        '-   User#Num: [wooorm#26](https://github.com/wooorm/' +
+        '-   # Num: [#26](' + baseUrl + user + '/' + project + '/issues/26)',
+        '-   GH-Num: [GH-26](' + baseUrl + user + '/' + project + '/issues/26)',
+        '-   User#Num: [wooorm#26](' +
+          baseUrl +
+          'wooorm/' +
           project +
           '/issues/26)',
         ''
@@ -194,6 +221,36 @@ test('Miscellaneous', function (t) {
     },
     /Missing `repository`/,
     'should throw without `repository`'
+  )
+
+  process.chdir(original)
+
+  t.end()
+})
+
+test('Base URL', function (t) {
+  var original = process.cwd()
+
+  t.equal(
+    github('test@12345678', {baseUrl: 'https://enteprise-github.xyz:443'}),
+    '[test@`1234567`](https://enteprise-github.xyz:443/' +
+      'test/remark-github/commit/12345678)\n',
+    'should use explicitly provided first'
+  )
+
+  t.equal(
+    github('test@12345678', null),
+    '[test@`1234567`](https://github.com/' +
+      'test/remark-github/commit/12345678)\n',
+    'should load a `package.json` when available'
+  )
+
+  process.chdir(__dirname)
+
+  t.equal(
+    github('12345678', null),
+    '[`1234567`](https://github.com/wooorm/remark/commit/12345678)\n',
+    'should accept a `repository.url` in a `package.json`'
   )
 
   process.chdir(original)

--- a/test/index.js
+++ b/test/index.js
@@ -250,7 +250,7 @@ test('Base URL', function (t) {
   t.equal(
     github('12345678', null),
     '[`1234567`](https://github.com/wooorm/remark/commit/12345678)\n',
-    'should accept a `repository.url` in a `package.json`'
+    'should default to https://github.com'
   )
 
   process.chdir(original)

--- a/test/index.js
+++ b/test/index.js
@@ -56,30 +56,18 @@ test('Fixtures', function (t) {
 // List of repo references possible in `package.json`s.
 // From repo-utils/parse-github-repo-url, with some tiny additions.
 var repositories = [
-  ['component/emitter', 'component', 'emitter', 'https://github.com/'],
-  [
-    'https://github.com/component/emitter',
-    'component',
-    'emitter',
-    'https://github.com/'
-  ],
-  [
-    'git://github.com/component/emitter.git',
-    'component',
-    'emitter',
-    'https://github.com/'
-  ],
+  ['component/emitter', 'component', 'emitter'],
+  ['https://github.com/component/emitter', 'component', 'emitter'],
+  ['git://github.com/component/emitter.git', 'component', 'emitter'],
   [
     'https://github.com/repos/component/emitter/tarball',
     'component',
-    'emitter',
-    'https://github.com/'
+    'emitter'
   ],
   [
     'https://github.com/repos/component/emitter/zipball',
     'component',
-    'emitter',
-    'https://github.com/'
+    'emitter'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.zip',
@@ -93,27 +81,20 @@ var repositories = [
     'emitter',
     'https://codeload.github.com/'
   ],
-  ['component/emitter#1', 'component', 'emitter', 'https://github.com/'],
-  ['component/emitter@1', 'component', 'emitter', 'https://github.com/'],
-  ['component/emitter#"1"', 'component', 'emitter', 'https://github.com/'],
-  ['component/emitter@"1"', 'component', 'emitter', 'https://github.com/'],
-  [
-    'git://github.com/component/emitter.git#1',
-    'component',
-    'emitter',
-    'https://github.com/'
-  ],
+  ['component/emitter#1', 'component', 'emitter'],
+  ['component/emitter@1', 'component', 'emitter'],
+  ['component/emitter#"1"', 'component', 'emitter'],
+  ['component/emitter@"1"', 'component', 'emitter'],
+  ['git://github.com/component/emitter.git#1', 'component', 'emitter'],
   [
     'https://github.com/repos/component/emitter/tarball/1',
     'component',
-    'emitter',
-    'https://github.com/'
+    'emitter'
   ],
   [
     'https://github.com/repos/component/emitter/zipball/1',
     'component',
-    'emitter',
-    'https://github.com/'
+    'emitter'
   ],
   [
     'https://codeload.github.com/component/emitter/legacy.zip/1',
@@ -130,26 +111,20 @@ var repositories = [
   [
     'https://github.com/component/emitter/archive/1.tar.gz',
     'component',
-    'emitter',
-    'https://github.com/'
+    'emitter'
   ],
-  ['mame/_', 'mame', '_', 'https://github.com/'],
-  ['github/.gitignore', 'github', '.gitignore', 'https://github.com/'],
-  ['github/.gitc', 'github', '.gitc', 'https://github.com/'],
-  ['Qix-/color-convert', 'Qix-', 'color-convert', 'https://github.com/'],
-  [
-    'wooorm/wooorm.github.io',
-    'wooorm',
-    'wooorm.github.io',
-    'https://github.com/'
-  ]
+  ['mame/_', 'mame', '_'],
+  ['github/.gitignore', 'github', '.gitignore'],
+  ['github/.gitc', 'github', '.gitc'],
+  ['Qix-/color-convert', 'Qix-', 'color-convert'],
+  ['wooorm/wooorm.github.io', 'wooorm', 'wooorm.github.io']
 ]
 
 test('Repositories', function (t) {
   repositories.forEach(function (repo) {
     var user = repo[1]
     var project = repo[2]
-    var baseUrl = repo[3]
+    var baseUrl = repo[3] || 'https://github.com/'
 
     repo = repo[0]
 
@@ -232,26 +207,23 @@ test('Base URL', function (t) {
   var original = process.cwd()
 
   t.equal(
-    github('12345678', {baseUrl: 'https://enteprise-github.xyz:443'}),
-    '[`1234567`](https://enteprise-github.xyz:443/' +
-      'remarkjs/remark-github/commit/12345678)\n',
+    github('12345678', {baseUrl: 'https://enteprise-github.xyz:8080'}),
+    '[`1234567`](https://enteprise-github.xyz:8080/remarkjs/remark-github/commit/12345678)\n',
     'should use explicitly provided first'
   )
 
   t.equal(
     github('12345678', {
-      baseUrl: 'https://enteprise-github.xyz:443',
+      baseUrl: 'https://enteprise-github.xyz:8080',
       repository: 'foo/bar'
     }),
-    '[`1234567`](https://enteprise-github.xyz:443/' +
-      'foo/bar/commit/12345678)\n',
+    '[`1234567`](https://enteprise-github.xyz:8080/foo/bar/commit/12345678)\n',
     'should work together with repository'
   )
 
   t.equal(
     github('12345678', null),
-    '[`1234567`](https://github.com/' +
-      'remarkjs/remark-github/commit/12345678)\n',
+    '[`1234567`](https://github.com/remarkjs/remark-github/commit/12345678)\n',
     'should load a `package.json` when available'
   )
 

--- a/test/index.js
+++ b/test/index.js
@@ -232,16 +232,26 @@ test('Base URL', function (t) {
   var original = process.cwd()
 
   t.equal(
-    github('test@12345678', {baseUrl: 'https://enteprise-github.xyz:443'}),
-    '[test@`1234567`](https://enteprise-github.xyz:443/' +
-      'test/remark-github/commit/12345678)\n',
+    github('12345678', {baseUrl: 'https://enteprise-github.xyz:443'}),
+    '[`1234567`](https://enteprise-github.xyz:443/' +
+      'remarkjs/remark-github/commit/12345678)\n',
     'should use explicitly provided first'
   )
 
   t.equal(
-    github('test@12345678', null),
-    '[test@`1234567`](https://github.com/' +
-      'test/remark-github/commit/12345678)\n',
+    github('12345678', {
+      baseUrl: 'https://enteprise-github.xyz:443',
+      repository: 'foo/bar'
+    }),
+    '[`1234567`](https://enteprise-github.xyz:443/' +
+      'foo/bar/commit/12345678)\n',
+    'should work together with repository'
+  )
+
+  t.equal(
+    github('12345678', null),
+    '[`1234567`](https://github.com/' +
+      'remarkjs/remark-github/commit/12345678)\n',
     'should load a `package.json` when available'
   )
 


### PR DESCRIPTION
Solves #23 

I used 2 `url` functions, both added in Node.js v0.1.25 
- `url.resolve` - safer way to resolve base + path 
- `url.parse` - see if hostname is present in whatever `repostiory` is set to

I had to update all the test cases that mentioned `https://codeload.github.com/`, by the new rules they resolve to `https://codeload.github.com/`
