### PR TITLE
Add `buildUrl` option for GH enterprise, custom URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "author": "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)",
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)",
-    "Anthony Maki <4cm4k1@gmail.com>"
+    "Anthony Maki <4cm4k1@gmail.com>",
+    "Ev Haus <ev@haus.gg>"
   ],
   "sideEffects": false,
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,30 @@ in GitHub issues, PRs, and comments (see
 *   At-mentions:
     `@wooorm` → [**@wooorm**][mention]
 
+##### Custom URLs
+
+By default we build URLs to public GitHub.
+You can overwrite them to point to GitHub Enterprise or other places by passing
+a `buildUrl`.
+That function is given an object with different values and the default
+`buildUrl`.
+
+```js
+remark()
+  .use(remarkGithub, {
+    // The fields in `values` depends on the kind reference:
+    // {type: 'commit', hash, project, user}
+    // {type: 'hashrange', base, compare, project, user}
+    // {type: 'issue', no, project, user}
+    // {type: 'mention', user}
+    buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'mention'
+            ? `https://yourwebsite.com/${values.user}/`
+            : defaultBuildUrl(values)
+    }
+  })
+```
+
 ###### Repository
 
 These links are generated relative to a project.

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,94 @@ test('Repositories', (t) => {
   t.end()
 })
 
+test('Custom URL builder option', (t) => {
+  t.equal(
+    github('@wooorm', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'mention'
+          ? `https://github.yourcompany.com/${values.user}/`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[**@wooorm**](https://github.yourcompany.com/wooorm/)\n',
+    'should support custom `baseUrl` function value for mentions'
+  )
+
+  t.equal(
+    github('#123', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'issue'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/issues/${values.no}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[#123](https://github.yourcompany.com/remarkjs/remark-github/issues/123)\n',
+    'should support custom `baseUrl` function value for issues'
+  )
+
+  t.equal(
+    github('GH-1', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'issue'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/issues/${values.no}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[GH-1](https://github.yourcompany.com/remarkjs/remark-github/issues/1)\n',
+    'should support custom `baseUrl` function value for non-standard issues'
+  )
+
+  t.equal(
+    github('e2acebc...2aa9311', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'compare'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/compare/${values.base}...${values.compare}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[`e2acebc...2aa9311`](https://github.yourcompany.com/remarkjs/remark-github/compare/e2acebc...2aa9311)\n',
+    'should support custom `baseUrl` function value for hash ranges'
+  )
+
+  t.equal(
+    github('1f2a4fb', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'commit'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/commit/${values.hash}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[`1f2a4fb`](https://github.yourcompany.com/remarkjs/remark-github/commit/1f2a4fb)\n',
+    'should support custom `baseUrl` function value for commit hashes'
+  )
+
+  t.equal(
+    github('remarkjs/remark-github#1', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'issue'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/issues/${values.no}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[#1](https://github.yourcompany.com/remarkjs/remark-github/issues/1)\n',
+    'should support custom `baseUrl` function value for cross-project issue references'
+  )
+
+  t.equal(
+    github('remarkjs/remark-github@1f2a4fb', {
+      buildUrl: (values, defaultBuildUrl) => {
+        return values.type === 'commit'
+          ? `https://github.yourcompany.com/${values.user}/${values.project}/commit/${values.hash}`
+          : defaultBuildUrl(values)
+      }
+    }),
+    '[@`1f2a4fb`](https://github.yourcompany.com/remarkjs/remark-github/commit/1f2a4fb)\n',
+    'should support custom `baseUrl` function value for cross-project hash references'
+  )
+
+  t.end()
+})
+
 test('Miscellaneous', (t) => {
   const original = process.cwd()
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The PR adds support for a new `githubUrl` option. This is specifically to address #23 but it goes a little bit further than the original PR for it (#24) and allows the option to be a function. This is because, I work on the [ZenHub](https://zenhub.com) team and we would love to use this package in our application but our application requires that the URL is sometimes going to github.com (such as for @ mentions) but other times it should go to zenhub.com (such as for issue references). By allowing the option to be a function, we can be add this customization while keeping the `remark-github` package simple and easy to test.

I've added documentation and tests for all the affected code paths. Coverage remains at 100%.

<!--do not edit: pr-->
