### PR TITLE
Remove `node:` protocols for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@
  *   Repository to link against.
  */
 
-import fs from 'node:fs'
-import process from 'node:process'
-import path from 'node:path'
+import fs from 'fs'
+import process from 'process'
+import path from 'path'
 import {visit} from 'unist-util-visit'
 import {toString} from 'mdast-util-to-string'
 import {findAndReplace} from 'mdast-util-find-and-replace'

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "trailingComma": "none"
   },
   "xo": {
-    "prettier": true
+    "prettier": true,
+    "rules": {
+      "unicorn/prefer-node-protocol": "off"
+    }
   },
   "remarkConfig": {
     "plugins": [

--- a/test/index.js
+++ b/test/index.js
@@ -3,9 +3,9 @@
  * @typedef {import('../index.js').Options} Options
  */
 
-import fs from 'node:fs'
-import path from 'node:path'
-import process from 'node:process'
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
 import test from 'tape'
 import {remark} from 'remark'
 import remarkGfm from 'remark-gfm'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

We are trying to use `remark-github` in the browser using webpack@5. I'm having a great deal of difficulty getting it to work because of the `node:` imports which `webpack` is failing to parse. Would you consider not using them until the webpack community can support such imports natively?

<!--do not edit: pr-->
