### PR TITLE
Extend options to customize links

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
  *
  * @callback DefaultBuildUrl
  * @param {BuildUrlValues} values
+ *   Override the base URL. Defaults to 'https://github.com'.
+ * @param {string} [base]
  * @returns {string}
  *
  * @callback BuildUrl
@@ -61,6 +63,10 @@
  *   But GitHub itself uses CSS instead of strong.
  * @property {BuildUrl} [buildUrl]
  *   Change how (and whether) things are linked.
+ * @property {string} [issueCharReplacement]
+ *   Replace the issue char (#) with something else.
+ * @property {string} [mentionCharReplacement]
+ *   Replace the mention char (@) with something else.
  */
 
 import {visit} from 'unist-util-visit'
@@ -191,14 +197,19 @@ export default function remarkGithub(options = {}) {
       const children = []
 
       if (link.page === 'issues' || link.page === 'pull') {
-        base += '#'
+        const issueStart = options.issueCharReplacement || '#'
+        base += issueStart
         children.push({
           type: 'text',
           value: base + link.reference + comment
         })
       } else {
         if (base) {
-          children.push({type: 'text', value: base + '@'})
+          const mentionStart = options.mentionCharReplacement || '@'
+          children.push({
+            type: 'text',
+            value: base + mentionStart
+          })
         }
 
         children.push({type: 'inlineCode', value: link.reference})
@@ -240,6 +251,10 @@ export default function remarkGithub(options = {}) {
 
     if (!url) return false
 
+    if (options.mentionCharReplacement && value.charAt(0) === '@') {
+      value = options.mentionCharReplacement + value.slice(1)
+    }
+
     /** @type {StaticPhrasingContent} */
     let node = {type: 'text', value}
 
@@ -266,8 +281,17 @@ export default function remarkGithub(options = {}) {
 
     const url = buildUrl({type: 'issue', ...repositoryInfo, no})
 
+    if (options.issueCharReplacement && value.charAt(0) === '#') {
+      value = options.issueCharReplacement + value.slice(1)
+    }
+
     return url
-      ? {type: 'link', title: null, url, children: [{type: 'text', value}]}
+      ? {
+          type: 'link',
+          title: null,
+          url,
+          children: [{type: 'text', value}]
+        }
       : false
   }
 
@@ -369,7 +393,8 @@ export default function remarkGithub(options = {}) {
     }
 
     if (no) {
-      value += '#' + no
+      const issueStart = options.issueCharReplacement || '#'
+      value += issueStart + no
     } else {
       value += '@'
       nodes.push({type: 'inlineCode', value: abbr(hash)})
@@ -396,9 +421,7 @@ function abbr(sha) {
  *
  * @type {DefaultBuildUrl}
  */
-function defaultBuildUrl(values) {
-  const base = 'https://github.com'
-
+function defaultBuildUrl(values, base = 'https://github.com') {
   if (values.type === 'mention') return [base, values.user].join('/')
 
   const {project, user} = values

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "xo": "^0.46.0"
   },
   "scripts": {
-    "build": "rimraf \"test/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",
+    "build": "rimraf \"{lib,test}/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",
     "format": "remark . -qfo --ignore-pattern test/ && prettier . -w --loglevel warn && xo --fix",
     "test-api": "node --conditions development test/index.js",
     "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov npm run test-api",

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ It’s called with the following parameters:
 
 *   `values` (`BuildUrlValues`)
     — info on the link to build
-*   `defaultBuildUrl` (`(values: BuildUrlValues) => string`)
+*   `defaultBuildUrl` (`(values: BuildUrlValues, base?: string) => string`)
     — function that can be called to perform normal behavior
 
 It should return the URL to use (`string`) or `false` to not create a link.
@@ -202,6 +202,19 @@ The following schemas are passed as `BuildUrlValues`:
 *   `{type: 'compare', user, project, base, compare}`
 *   `{type: 'issue', user, project, no}`
 *   `{type: 'mention', user}`
+
+###### `options.issueCharReplacement`
+
+Replace the issue character (`#`) with something else (`string`, optional).
+This can be used, for example, to prevent the corresponding issues from
+receiving a reference when the generated Markdown is posted somewhere
+on GitHub.
+
+###### `options.mentionCharReplacement`
+
+Replace the mention character (`@`) with something else (`string`, optional).
+This can be used, for example, to prevent mentioned users from receiving
+a notification when the generated Markdown is posted somewhere on GitHub.
 
 ## Examples
 
@@ -239,6 +252,25 @@ To instead point mentions to a different place, change `example.js` like so:
 +        return values.type === 'mention'
 +          ? `https://yourwebsite.com/${values.user}/`
 +          : defaultBuildUrl(values)
++      }
++    })
+     .process(await read('example.md'))
+
+   console.log(String(file))
+```
+
+To only change the base URL (`https://github.com`) and otherwise keep the
+default behavior, change `example.js` like so:
+
+```diff
+@@ -8,7 +8,11 @@ main()
+ async function main() {
+   const file = await remark()
+     .use(remarkGfm)
+-    .use(remarkGithub)
++    .use(remarkGithub, {
++      buildUrl(values, defaultBuildUrl) {
++        return defaultBuildUrl(values, 'https://yourwebsite.com')
 +      }
 +    })
      .process(await read('example.md'))

--- a/test/fixtures/mention/input.md
+++ b/test/fixtures/mention/input.md
@@ -6,7 +6,7 @@ For example, @user, @organization, or @organization/team-name.
 
 GitHub ignores @mention and @mentions.
 
-Some valid real world examples: @a, @github, @github/security.
+Some valid real world examples: @a, @github, @github/security, @dependabot[bot].
 
 But this is invalid: @-w.
 

--- a/test/fixtures/mention/output.md
+++ b/test/fixtures/mention/output.md
@@ -6,7 +6,7 @@ For example, [**@user**](https://github.com/user), [**@organization**](https://g
 
 GitHub ignores @mention and @mentions.
 
-Some valid real world examples: [**@a**](https://github.com/a), [**@github**](https://github.com/github), [**@github/security**](https://github.com/github/security).
+Some valid real world examples: [**@a**](https://github.com/a), [**@github**](https://github.com/github), [**@github/security**](https://github.com/github/security), [**@dependabot**](https://github.com/dependabot)\[bot].
 
 But this is invalid: @-w.
 

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,18 @@ test('remark-github()', (t) => {
     'should support `mentionStrong: false`'
   )
 
+  t.equal(
+    github('#1', {issueCharReplacement: '#&#8203;'}),
+    '[#\\&#8203;1](https://github.com/remarkjs/remark-github/issues/1)\n',
+    'should support custom `issueCharReplacement`'
+  )
+
+  t.equal(
+    github('@wooorm', {mentionCharReplacement: '@&#8203;'}),
+    '[**@\\&#8203;wooorm**](https://github.com/wooorm)\n',
+    'should support custom `mentionCharReplacement`'
+  )
+
   t.end()
 })
 
@@ -271,6 +283,16 @@ test('Custom URL builder option', (t) => {
     ),
     '@user, #1, 1f2a4fb, e2acebc...2aa9311, remarkjs/remark-github#1, remarkjs/remark-github\\@1f2a4fb\n',
     'should support `buildUrl` returning `false` to not link something'
+  )
+
+  t.equal(
+    github('@wooorm, #123', {
+      buildUrl(values, defaultBuildUrl) {
+        return defaultBuildUrl(values, 'https://github.yourcompany.com')
+      }
+    }),
+    '[**@wooorm**](https://github.yourcompany.com/wooorm), [#123](https://github.yourcompany.com/remarkjs/remark-github/issues/123)\n',
+    'should support `buildUrl` using `defaultBuildUrl` with custom base URL'
   )
 
   t.end()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This pull request extends the link customization options as follows:

* Allow to override the default base URL (`https://github.com`) in the `defaultBuildUrl` function by passing the desired URL in the second parameter, for example:

  ```js
  .use(remarkGithub, {
    buildUrl(values, defaultBuildUrl) {
      return defaultBuildUrl(values, 'https://yourwebsite.com')
    }
  })
  ```

  This is useful if you only want to change the base URL (e.g. GitHub Enterprise) and otherwise keep the default "build URL" behavior.
* Two new options to replace the issue / mention characters (`#` / `@`) with something else.
  
  In my case, I'm using the generated Markdown to create automated comments on GitHub pull requests.
  GitHub automatically notifies mentioned users and displays references in issues linking to those comments which is something I'd like to prevent in that case.
  With those two options I'm able to do so by inserting a zero-width space after the issue / mention characters:

  ```js
  const zeroWidthSpace = '​'
  [...]
    .use(remarkGithub, {
      issueCharReplacement: `#${zeroWidthSpace}`,
      mentionCharReplacement: `@${zeroWidthSpace}`
    })
  ```

  This might be a bit specific, but I know of other applications (like [Renovate](https://github.com/renovatebot/renovate/blob/main/lib/util/markdown.ts)) that have the same problem and could also benefit from such options.
  I'd be pleased if those options were adopted in `remark-github`, as otherwise I'd have to re-implement most of its logic again outside of it. Of course I'm open for adjustments!

---

In addition, this pull request also contains two enhancements in separate commits:

*  [Add dependabot to real world examples in test](https://github.com/remarkjs/remark-github/commit/dc7f6481adad33a2516e6b227ef5bdf5dd440764)
* [Fix build command](https://github.com/remarkjs/remark-github/commit/ec5f545a08ff56bed8cc3d024ff39cb3b339511e)

<!--do not edit: pr-->
