### PR TITLE
Fix to resolve `package.json`s from file, not `process`

### DIFF
--- a/lib/get-repo-from-package.js
+++ b/lib/get-repo-from-package.js
@@ -3,22 +3,20 @@
  */
 
 import fs from 'fs'
-import process from 'process'
 import path from 'path'
 
 /**
  * Get the repository from `package.json`.
  *
+ * @param {string} cwd
  * @returns {string|undefined}
  */
-export function getRepoFromPackage() {
+export function getRepoFromPackage(cwd) {
   /** @type {PackageJson|undefined} */
   let pkg
 
   try {
-    pkg = JSON.parse(
-      String(fs.readFileSync(path.join(process.cwd(), 'package.json')))
-    )
+    pkg = JSON.parse(String(fs.readFileSync(path.join(cwd, 'package.json'))))
   } catch {}
 
   const repository =

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,19 +139,22 @@ const mentionRegex = new RegExp(
  * @type {import('unified').Plugin<[Options?]|void[], Root>}
  */
 export default function remarkGithub(options = {}) {
-  const repository = options.repository || getRepoFromPackage()
+  return (tree, vfile) => {
+    const repository = options.repository || getRepoFromPackage(vfile.cwd)
 
-  // Parse the URL: See the tests for all possible kinds.
-  const repositoryMatch = repoRegex.exec(repository || '')
+    // Parse the URL: See the tests for all possible kinds.
+    const repositoryMatch = repoRegex.exec(repository || '')
 
-  if (!repositoryMatch) {
-    throw new Error('Missing or invalid `repository` field in `options`')
-  }
+    if (!repositoryMatch) {
+      throw new Error('Missing or invalid `repository` field in `options`')
+    }
 
-  /** @type {RepositoryInfo} */
-  const repositoryInfo = {user: repositoryMatch[1], project: repositoryMatch[2]}
+    /** @type {RepositoryInfo} */
+    const repositoryInfo = {
+      user: repositoryMatch[1],
+      project: repositoryMatch[2]
+    }
 
-  return (tree) => {
     findAndReplace(
       tree,
       [
@@ -210,174 +213,174 @@ export default function remarkGithub(options = {}) {
 
       node.children = children
     })
-  }
 
-  /**
-   * @param {BuildUrlValues} values
-   * @returns {string|false}
-   */
-  function buildUrl(values) {
-    if (options.buildUrl) return options.buildUrl(values, defaultBuildUrl)
-    return defaultBuildUrl(values)
-  }
-
-  /**
-   * @type {ReplaceFunction}
-   * @param {string} value
-   * @param {string} username
-   * @param {Match} match
-   */
-  function replaceMention(value, username, match) {
-    if (
-      /[\w`]/.test(match.input.charAt(match.index - 1)) ||
-      /[/\w`]/.test(match.input.charAt(match.index + value.length)) ||
-      denyMention.has(username)
-    ) {
-      return false
+    /**
+     * @param {BuildUrlValues} values
+     * @returns {string|false}
+     */
+    function buildUrl(values) {
+      if (options.buildUrl) return options.buildUrl(values, defaultBuildUrl)
+      return defaultBuildUrl(values)
     }
 
-    const url = buildUrl({type: 'mention', user: username})
+    /**
+     * @type {ReplaceFunction}
+     * @param {string} value
+     * @param {string} username
+     * @param {Match} match
+     */
+    function replaceMention(value, username, match) {
+      if (
+        /[\w`]/.test(match.input.charAt(match.index - 1)) ||
+        /[/\w`]/.test(match.input.charAt(match.index + value.length)) ||
+        denyMention.has(username)
+      ) {
+        return false
+      }
 
-    if (!url) return false
+      const url = buildUrl({type: 'mention', user: username})
 
-    /** @type {StaticPhrasingContent} */
-    let node = {type: 'text', value}
+      if (!url) return false
 
-    if (options.mentionStrong !== false) {
-      node = {type: 'strong', children: [node]}
+      /** @type {StaticPhrasingContent} */
+      let node = {type: 'text', value}
+
+      if (options.mentionStrong !== false) {
+        node = {type: 'strong', children: [node]}
+      }
+
+      return {type: 'link', title: null, url, children: [node]}
     }
 
-    return {type: 'link', title: null, url, children: [node]}
-  }
+    /**
+     * @type {ReplaceFunction}
+     * @param {string} value
+     * @param {string} no
+     * @param {Match} match
+     */
+    function replaceIssue(value, no, match) {
+      if (
+        /\w/.test(match.input.charAt(match.index - 1)) ||
+        /\w/.test(match.input.charAt(match.index + value.length))
+      ) {
+        return false
+      }
 
-  /**
-   * @type {ReplaceFunction}
-   * @param {string} value
-   * @param {string} no
-   * @param {Match} match
-   */
-  function replaceIssue(value, no, match) {
-    if (
-      /\w/.test(match.input.charAt(match.index - 1)) ||
-      /\w/.test(match.input.charAt(match.index + value.length))
-    ) {
-      return false
+      const url = buildUrl({type: 'issue', ...repositoryInfo, no})
+
+      return url
+        ? {type: 'link', title: null, url, children: [{type: 'text', value}]}
+        : false
     }
 
-    const url = buildUrl({type: 'issue', ...repositoryInfo, no})
+    /**
+     * @type {ReplaceFunction}
+     * @param {string} value
+     * @param {string} a
+     * @param {string} b
+     * @param {Match} match
+     */
+    function replaceHashRange(value, a, b, match) {
+      if (
+        /[^\t\n\r (@[{]/.test(match.input.charAt(match.index - 1)) ||
+        /\w/.test(match.input.charAt(match.index + value.length)) ||
+        denyHash.has(value)
+      ) {
+        return false
+      }
 
-    return url
-      ? {type: 'link', title: null, url, children: [{type: 'text', value}]}
-      : false
-  }
+      const url = buildUrl({
+        type: 'compare',
+        ...repositoryInfo,
+        base: a,
+        compare: b
+      })
 
-  /**
-   * @type {ReplaceFunction}
-   * @param {string} value
-   * @param {string} a
-   * @param {string} b
-   * @param {Match} match
-   */
-  function replaceHashRange(value, a, b, match) {
-    if (
-      /[^\t\n\r (@[{]/.test(match.input.charAt(match.index - 1)) ||
-      /\w/.test(match.input.charAt(match.index + value.length)) ||
-      denyHash.has(value)
-    ) {
-      return false
+      return url
+        ? {
+            type: 'link',
+            title: null,
+            url,
+            children: [{type: 'inlineCode', value: abbr(a) + '...' + abbr(b)}]
+          }
+        : false
     }
 
-    const url = buildUrl({
-      type: 'compare',
-      ...repositoryInfo,
-      base: a,
-      compare: b
-    })
+    /**
+     * @type {ReplaceFunction}
+     * @param {string} value
+     * @param {Match} match
+     */
+    function replaceHash(value, match) {
+      if (
+        /[^\t\n\r (@[{.]/.test(match.input.charAt(match.index - 1)) ||
+        // For some weird reason GH does link two dots, but not one 🤷‍♂️
+        (match.input.charAt(match.index - 1) === '.' &&
+          match.input.charAt(match.index - 2) !== '.') ||
+        /\w/.test(match.input.charAt(match.index + value.length)) ||
+        denyHash.has(value)
+      ) {
+        return false
+      }
 
-    return url
-      ? {
-          type: 'link',
-          title: null,
-          url,
-          children: [{type: 'inlineCode', value: abbr(a) + '...' + abbr(b)}]
-        }
-      : false
-  }
+      const url = buildUrl({type: 'commit', ...repositoryInfo, hash: value})
 
-  /**
-   * @type {ReplaceFunction}
-   * @param {string} value
-   * @param {Match} match
-   */
-  function replaceHash(value, match) {
-    if (
-      /[^\t\n\r (@[{.]/.test(match.input.charAt(match.index - 1)) ||
-      // For some weird reason GH does link two dots, but not one 🤷‍♂️
-      (match.input.charAt(match.index - 1) === '.' &&
-        match.input.charAt(match.index - 2) !== '.') ||
-      /\w/.test(match.input.charAt(match.index + value.length)) ||
-      denyHash.has(value)
-    ) {
-      return false
+      return url
+        ? {
+            type: 'link',
+            title: null,
+            url,
+            children: [{type: 'inlineCode', value: abbr(value)}]
+          }
+        : false
     }
 
-    const url = buildUrl({type: 'commit', ...repositoryInfo, hash: value})
+    /**
+     * @type {ReplaceFunction}
+     * @param {string} $0
+     * @param {string} user
+     * @param {string} specificProject
+     * @param {string} no
+     * @param {string} hash
+     * @param {Match} match
+     */
+    // eslint-disable-next-line max-params
+    function replaceReference($0, user, specificProject, no, hash, match) {
+      if (
+        /[^\t\n\r (@[{]/.test(match.input.charAt(match.index - 1)) ||
+        /\w/.test(match.input.charAt(match.index + $0.length))
+      ) {
+        return false
+      }
 
-    return url
-      ? {
-          type: 'link',
-          title: null,
-          url,
-          children: [{type: 'inlineCode', value: abbr(value)}]
-        }
-      : false
-  }
+      const project = specificProject || repositoryInfo.project
+      const url = no
+        ? buildUrl({type: 'issue', user, project, no})
+        : buildUrl({type: 'commit', user, project, hash})
 
-  /**
-   * @type {ReplaceFunction}
-   * @param {string} $0
-   * @param {string} user
-   * @param {string} specificProject
-   * @param {string} no
-   * @param {string} hash
-   * @param {Match} match
-   */
-  // eslint-disable-next-line max-params
-  function replaceReference($0, user, specificProject, no, hash, match) {
-    if (
-      /[^\t\n\r (@[{]/.test(match.input.charAt(match.index - 1)) ||
-      /\w/.test(match.input.charAt(match.index + $0.length))
-    ) {
-      return false
+      if (!url) return false
+
+      /** @type {StaticPhrasingContent[]} */
+      const nodes = []
+      let value = ''
+
+      if (project !== repositoryInfo.project) {
+        value += user + '/' + project
+      } else if (user !== repositoryInfo.user) {
+        value += user
+      }
+
+      if (no) {
+        value += '#' + no
+      } else {
+        value += '@'
+        nodes.push({type: 'inlineCode', value: abbr(hash)})
+      }
+
+      nodes.unshift({type: 'text', value})
+
+      return {type: 'link', title: null, url, children: nodes}
     }
-
-    const project = specificProject || repositoryInfo.project
-    const url = no
-      ? buildUrl({type: 'issue', user, project, no})
-      : buildUrl({type: 'commit', user, project, hash})
-
-    if (!url) return false
-
-    /** @type {StaticPhrasingContent[]} */
-    const nodes = []
-    let value = ''
-
-    if (project !== repositoryInfo.project) {
-      value += user + '/' + project
-    } else if (user !== repositoryInfo.user) {
-      value += user
-    }
-
-    if (no) {
-      value += '#' + no
-    } else {
-      value += '@'
-      nodes.push({type: 'inlineCode', value: abbr(hash)})
-    }
-
-    nodes.unshift({type: 'text', value})
-
-    return {type: 'link', title: null, url, children: nodes}
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "type-coverage": "^2.0.0",
     "type-fest": "^2.0.0",
     "typescript": "^4.0.0",
+    "vfile": "^5.0.0",
     "xo": "^0.48.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -5,10 +5,10 @@
 
 import fs from 'fs'
 import path from 'path'
-import process from 'process'
 import test from 'tape'
 import {remark} from 'remark'
 import remarkGfm from 'remark-gfm'
+import {VFile} from 'vfile'
 import remarkGitHub from '../index.js'
 
 const join = path.join
@@ -277,34 +277,44 @@ test('Custom URL builder option', (t) => {
 })
 
 test('Miscellaneous', (t) => {
-  const original = process.cwd()
-
   t.equal(
-    github('test@12345678', null),
+    github(
+      new VFile({
+        value: 'test@12345678',
+        cwd: new URL('..', import.meta.url).pathname
+      }),
+      null
+    ),
     '[test@`1234567`](https://github.com/' +
       'test/remark-github/commit/12345678)\n',
     'should load a `package.json` when available'
   )
 
-  process.chdir(path.join(process.cwd(), 'test'))
-
   t.equal(
-    github('12345678', null),
+    github(
+      new VFile({
+        value: '12345678',
+        cwd: new URL('.', import.meta.url).pathname
+      }),
+      null
+    ),
     '[`1234567`](https://github.com/wooorm/remark/commit/12345678)\n',
     'should accept a `repository.url` in a `package.json`'
   )
 
-  process.chdir(join(process.cwd(), 'fixtures'))
-
   t.throws(
     () => {
-      github('1234567', null)
+      github(
+        new VFile({
+          value: '12345678',
+          cwd: new URL('./fixtures', import.meta.url).pathname
+        }),
+        null
+      )
     },
     /Missing or invalid `repository`/,
     'should throw without `repository`'
   )
-
-  process.chdir(original)
 
   t.end()
 })
@@ -312,7 +322,7 @@ test('Miscellaneous', (t) => {
 /***
  * Shortcut to process.
  *
- * @param {string} value
+ * @param {string|VFile} value
  * @param {string|Options|null} [repo]
  */
 function github(value, repo) {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The plugin might be run from an unexpected cwd, i.e. using `remark-language-server` in VS Code in Windows.

Due to variable scoping changes, there are a lot of indentation changes. I recommend reviewers to hide those.

Closes #39

<!--do not edit: pr-->
