### PR TITLE
fix(regex): accepting numbers in name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ const minShaLength = 7
 // cannot begin or end with a hyphen*.
 //
 // \* That is: until <https://github.com/remarkjs/remark-github/issues/13>.
-const userGroup = '[\\da-z][-\\da-z]{0,38}'
+const userGroup = '[\\da-z][-\\da-z0-9]{0,38}'
 const projectGroup = '(?:\\.git[\\w-]|\\.(?!git)|[\\w-])+'
 const repoGroup = '(' + userGroup + ')\\/(' + projectGroup + ')'
 

--- a/test/fixtures/mention/input.md
+++ b/test/fixtures/mention/input.md
@@ -6,7 +6,7 @@ For example, @user, @organization, or @organization/team-name.
 
 GitHub ignores @mention and @mentions.
 
-Some valid real world examples: @a, @github, @github/security, @dependabot[bot].
+Some valid real world examples: @a, @github, @github/security, @dependabot[bot], @myname0.
 
 But this is invalid: @-w.
 

--- a/test/fixtures/mention/output.md
+++ b/test/fixtures/mention/output.md
@@ -6,7 +6,7 @@ For example, [**@user**](https://github.com/user), [**@organization**](https://g
 
 GitHub ignores @mention and @mentions.
 
-Some valid real world examples: [**@a**](https://github.com/a), [**@github**](https://github.com/github), [**@github/security**](https://github.com/github/security), [**@dependabot**](https://github.com/dependabot)\[bot].
+Some valid real world examples: [**@a**](https://github.com/a), [**@github**](https://github.com/github), [**@github/security**](https://github.com/github/security), [**@dependabot**](https://github.com/dependabot)\[bot], [**@myname0**](https://github.com/myname0).
 
 But this is invalid: @-w.
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The current userGroup doesn't accept number in name, even though it is a valid user `i.e: myname0`. This PR aims to address that problem.

<!--do not edit: pr-->
