### PR TITLE
Support Enterprise Managed User in userGroup Regex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,10 +132,11 @@ const denyHash = new Set([
 const minShaLength = 7
 
 // Username may only contain alphanumeric characters or single hyphens, and
-// cannot begin or end with a hyphen*.
+// cannot begin or end with a hyphen*. Enterprise Managed Users can have
+// underscores.
 //
 // \* That is: until <https://github.com/remarkjs/remark-github/issues/13>.
-const userGroup = '[\\da-z][-\\da-z]{0,38}'
+const userGroup = '[\\da-z](?:[-_\\da-z]{0,37}[\\da-z-])?'
 const projectGroup = '(?:\\.git[\\w-]|\\.(?!git)|[\\w-])+'
 const repoGroup = '(' + userGroup + ')\\/(' + projectGroup + ')'
 

--- a/test/index.js
+++ b/test/index.js
@@ -118,6 +118,26 @@ test('remarkGithub', async function (t) {
     }
   })
 
+  await t.test(
+    'should not throw w/ `repository` that belongs to an Enterprise Managed User',
+    async function () {
+      const file = await remark()
+        .use(remarkGfm)
+        .use(remarkGithub, {repository: 'a_zse/b'})
+        .process(
+          new VFile({
+            cwd: new URL('.', import.meta.url).pathname,
+            value: '12345678'
+          })
+        )
+
+      assert.equal(
+        String(file),
+        '[`1234567`](https://github.com/a_zse/b/commit/12345678)\n'
+      )
+    }
+  )
+
   await t.test('should support `buildUrl` for mentions', async function () {
     const file = await remark()
       .use(remarkGfm)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

A GitHub Enterprise customer discovered a bug in our product today (that uses `remark-github`). Their code was crashing with:

```
Unexpected invalid `repository`, expected for example `user/project`
```

After a bunch of troubleshooting I discovered it's because their GitHub username has an `_` (underscore) in it. Turns out although generally this is not allowed on GitHub, Enterprise Managed Users can have underscores (see [official docs](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/iam-configuration-reference/username-considerations-for-external-authentication)).

This PR updates the Regex to support this and adds a unit test to catch this edge case.

<!--do not edit: pr-->
